### PR TITLE
Update README with instructions on how to setup a secure remote connection to your mpv instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Restart Home Assistant and enjoy!
 
 It is also possible to connect to a remote mpv instance over the network. For security reasons, it's strongly recommended to use SSH tunneling to create an encrypted connection rather than exposing the socket directly over the network. Directly exposing the mpv control socket is a security risk, as it would allow anybody with access to the port to execute arbitrary commands via mpv's `run` command.
 
-First, ensure that `socat` is installed, and create a script that runs socat with an SSH tunnel to securely expose the mpv socket (port 2352 in the following example). It is important that this script has the extension `.run`, and is executable (run `chmod +x secure-tunnel.run`):
+First, ensure that `socat` is installed, and create a script that runs socat with an SSH tunnel to securely expose the mpv socket (port 2352 in the following example). It is important that this script has the extension `.run`, and is executable (run `chmod +x secure-mpv-tunnel.run`):
 ```sh
 #!/bin/bash
 # Replace these values with your actual settings
@@ -52,7 +52,7 @@ ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${REMOTE_USER}@${REMOTE_HOST}
 
 Start mpv with the `--script` option to run the script on startup:
 ```sh
-mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/secure-tunnel.run
+mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/secure-mpv-tunnel.run
 ```
 
 Finally, configure the integration to connect to the local end of the tunnel:

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ First, ensure that `socat` is installed, and create a script that runs socat wit
 # Replace these values with your actual settings
 MPV_SOCKET="/path/to/mpv-socket"
 LOCAL_PORT="2352"
-REMOTE_HOST="homeassistant.local"  # Your Home Assistant machine
-REMOTE_USER="user"                 # SSH user on your Home Assistant machine
+HA_HOST="homeassistant.local"  # Your Home Assistant machine
+HA_USER="user"                 # SSH user on your Home Assistant machine
 
 # Create local TCP listener that connects to mpv socket
 socat TCP-LISTEN:${LOCAL_PORT},reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
 
 # Create secure SSH tunnel
-ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${REMOTE_USER}@${REMOTE_HOST}
+ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${HA_USER}@${HA_HOST}
 ```
 
 Start mpv with the `--script` option to run the script on startup:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ socat TCP-LISTEN:${LOCAL_PORT},reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
 ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${HA_USER}@${HA_HOST}
 ```
 
-> **Note:** If using the [Home Assistant SSH addon](https://github.com/hassio-addons/addon-ssh), you'll need to enable `allow_remote_port_forwarding: true` in its configuration.
+> **Note:** This method requires SSH access to your Home Assistant instance. If using the popular [Home Assistant SSH addon](https://github.com/hassio-addons/addon-ssh), you'll need to enable `allow_remote_port_forwarding: true` in its configuration for the reverse tunnel to work.
 
 Start mpv with the `--script` option to run the script on startup:
 ```sh

--- a/README.md
+++ b/README.md
@@ -32,28 +32,47 @@ Restart Home Assistant and enjoy!
 
 #### Remote mpv
 
-It is also possible to connect to a remove mpv instance over the network. First, ensure that `socat` is installed, and
-create a script that runs socat to expose the mpv socket on a network port (2352 in the following example). It is
-important that this script has the extension `.run`, and is executable (run `chmod +x socat.run`):
+It is also possible to connect to a remote mpv instance over the network. For security reasons, it's strongly recommended to use SSH tunneling to create an encrypted connection rather than exposing the socket directly over the network. Directly exposing the mpv control socket is a security risk, as it would allow anybody with access to the port to execute arbitrary commands via mpv's `run` command.
+
+First, ensure that `socat` is installed. Then create a script that:
+1. Starts a local TCP listener that connects to the mpv socket
+2. Creates an SSH tunnel to securely expose this listener to your Home Assistant machine
+
+Example secure connection script (save as `secure-mpv-tunnel.sh` and make executable with `chmod +x`):
 ```sh
-#!/bin/sh
-exec socat TCP-LISTEN:2352,fork UNIX-CONNECT:/path/to/mpv-socket
+#!/bin/bash
+# Replace these values with your actual settings
+MPV_SOCKET="/path/to/mpv-socket"
+LOCAL_PORT="2352"
+REMOTE_HOST="homeassistant.local"  # Your Home Assistant machine
+REMOTE_USER="user"                 # SSH user on your Home Assistant machine
+
+# Kill all background processes when script terminates
+trap "kill 0" SIGINT SIGTERM EXIT
+
+# Create local TCP listener that connects to mpv socket
+socat TCP-LISTEN:${LOCAL_PORT},reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
+
+# Create secure SSH tunnel
+ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${REMOTE_USER}@${REMOTE_HOST}
 ```
 
-Start mpv with using the `--script` option to have it run the script on startup:
+Start mpv with the `--script` option to run the script on startup:
 ```sh
-mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/socat.run
+mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/secure-mpv-tunnel.sh
 ```
 
-Finaly, configure the integration to connect over the network:
+Finally, configure the integration to connect to the local end of the tunnel:
 ```yaml
 media_player:
   - platform: mpv
     name: "MPV Player"
     server:
-      host: 192.168.1.100
+      host: localhost
       port: 2352
 ```
+
+This approach ensures all communication between Home Assistant and mpv is encrypted through SSH, preventing unauthorized access to your mpv instance.
 
 #### Other useful mpv options
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,7 @@ Restart Home Assistant and enjoy!
 
 It is also possible to connect to a remote mpv instance over the network. For security reasons, it's strongly recommended to use SSH tunneling to create an encrypted connection rather than exposing the socket directly over the network. Directly exposing the mpv control socket is a security risk, as it would allow anybody with access to the port to execute arbitrary commands via mpv's `run` command.
 
-First, ensure that `socat` is installed. Then create a script that:
-1. Starts a local TCP listener that connects to the mpv socket
-2. Creates an SSH tunnel to securely expose this listener to your Home Assistant machine
-
-Example secure connection script (save as `secure-mpv-tunnel.sh` and make executable with `chmod +x`):
+First, ensure that `socat` is installed, and create a script that runs socat with an SSH tunnel to securely expose the mpv socket (port 2352 in the following example). It is important that this script has the extension `.run`, and is executable (run `chmod +x secure-tunnel.run`):
 ```sh
 #!/bin/bash
 # Replace these values with your actual settings
@@ -46,9 +42,6 @@ MPV_SOCKET="/path/to/mpv-socket"
 LOCAL_PORT="2352"
 REMOTE_HOST="homeassistant.local"  # Your Home Assistant machine
 REMOTE_USER="user"                 # SSH user on your Home Assistant machine
-
-# Kill all background processes when script terminates
-trap "kill 0" SIGINT SIGTERM EXIT
 
 # Create local TCP listener that connects to mpv socket
 socat TCP-LISTEN:${LOCAL_PORT},reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
@@ -59,7 +52,7 @@ ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${REMOTE_USER}@${REMOTE_HOST}
 
 Start mpv with the `--script` option to run the script on startup:
 ```sh
-mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/secure-mpv-tunnel.sh
+mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/secure-tunnel.run
 ```
 
 Finally, configure the integration to connect to the local end of the tunnel:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ LOCAL_PORT="2352"
 HA_HOST="homeassistant.local"  # Your Home Assistant machine
 HA_USER="user"                 # SSH user on your Home Assistant machine
 
+# Exit if port already in use (script likely already running)
+if nc -z 127.0.0.1 ${LOCAL_PORT} 2>/dev/null; then
+  echo "Port ${LOCAL_PORT} already in use, assuming secure-mpv-tunnel script is already running"
+  exit 0
+fi
+
 # Create localhost-only TCP listener that connects to mpv socket
 socat TCP-LISTEN:${LOCAL_PORT},bind=127.0.0.1,reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ socat TCP-LISTEN:${LOCAL_PORT},reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
 ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${HA_USER}@${HA_HOST}
 ```
 
+> **Note:** If using the [Home Assistant SSH addon](https://github.com/hassio-addons/addon-ssh), you'll need to enable `allow_remote_port_forwarding: true` in its configuration.
+
 Start mpv with the `--script` option to run the script on startup:
 ```sh
 mpv --input-ipc-server=/path/to/mpv-socket --script=/path/to/secure-mpv-tunnel.run

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Restart Home Assistant and enjoy!
 
 It is also possible to connect to a remote mpv instance over the network. For security reasons, it's strongly recommended to use SSH tunneling to create an encrypted connection rather than exposing the socket directly over the network. Directly exposing the mpv control socket is a security risk, as it would allow anybody with access to the port to execute arbitrary commands via mpv's `run` command.
 
-First, ensure that `socat` is installed, and create a script that runs socat with an SSH tunnel to securely expose the mpv socket (port 2352 in the following example). It is important that this script has the extension `.run`, and is executable (run `chmod +x secure-mpv-tunnel.run`):
+First, ensure that `socat` is installed, and create a script that:
+1. Uses socat to bridge the mpv Unix socket to a localhost-only port on your machine
+2. Creates an SSH reverse tunnel to securely forward that port to your Home Assistant server
+
+The script must have the `.run` extension and be executable (run `chmod +x secure-mpv-tunnel.run`):
 ```sh
 #!/bin/bash
 # Replace these values with your actual settings
@@ -43,8 +47,8 @@ LOCAL_PORT="2352"
 HA_HOST="homeassistant.local"  # Your Home Assistant machine
 HA_USER="user"                 # SSH user on your Home Assistant machine
 
-# Create local TCP listener that connects to mpv socket
-socat TCP-LISTEN:${LOCAL_PORT},reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
+# Create localhost-only TCP listener that connects to mpv socket
+socat TCP-LISTEN:${LOCAL_PORT},bind=127.0.0.1,reuseaddr,fork UNIX-CONNECT:${MPV_SOCKET} &
 
 # Create secure SSH tunnel
 ssh -N -R ${LOCAL_PORT}:localhost:${LOCAL_PORT} ${HA_USER}@${HA_HOST}


### PR DESCRIPTION
The current guidance in the README for setting up a remote connection is insecure. mpv supports a `run` input command that allows executing arbitrary commands, meaning anyone with access to the exposed port could run `echo "run <any_command>" | nc <your_ip> 2352` to execute commands on your system.

For a trusted local network that's not a huge deal... but unless your security stance trusts everything on your LAN and you never leave it, it still doesn't make sense. If you had it running on a laptop while connected to some public WiFi networks, your computer would could be easily pwn'd by anyone. (fortunately this is obscure enough that most people aren't looking for it)

This update provides guidance on how to achieve the same remote connection securely using `socat` with SSH port forwarding. I've implemented this solution myself and can confirm it works great!

btw, thank you so much for making this project. I love mpv, and I love home assistant, and now I get to combine my interests!
